### PR TITLE
Fix misspelling of `install` and remove recommendation of using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Opens a file on Amazon S3 in default text editor.
 ###Installation
 One-line install
 
-    $ sudo npm instal s3edit -g
+    $ npm install s3edit -g
 
 ###Usage
 Open the file file.txt in the bucket myBucket


### PR DESCRIPTION
Firstly, thank you for this very cool tool!

`sudo npm install` is usually not necessary if the permissions on the file system are correct…

https://ar.al/scribbles/npm-install-g-please-try-running-this-command-again-as-root-administrator/
